### PR TITLE
example: show bumping apimachinery to v0.35.0-alpha.1

### DIFF
--- a/examples/argo_application/generated/k8s.io/apimachinery/pkg/util/intstr/types.go
+++ b/examples/argo_application/generated/k8s.io/apimachinery/pkg/util/intstr/types.go
@@ -11,6 +11,7 @@ package intstr
 // +protobuf=true
 // +protobuf.options.(gogoproto.goproto_stringer)=false
 // +k8s:openapi-gen=true
+// +k8s:openapi-model-package=io.k8s.apimachinery.pkg.util.intstr
 type IntOrString struct {
 	Type   Type   `protobuf:"varint,1,opt,name=type,casttype=Type"`
 	IntVal int32  `protobuf:"varint,2,opt,name=intVal"`

--- a/examples/argo_application/go.mod
+++ b/examples/argo_application/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/argoproj/gitops-engine v0.7.1-0.20251006172252-b89b0871b414 // indirect
-	k8s.io/apimachinery v0.34.1 // indirect
+	k8s.io/apimachinery v0.35.0-alpha.1 // indirect
 )
 
 replace github.com/argoproj/argo-cd/v3 => ./generated/github.com/argoproj/argo-cd/v3


### PR DESCRIPTION
```
go get k8s.io/apimachinery@v0.35.0-alpha.1
package-rewriter \
  --package github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1 \
  --type Application \
  --output ./generated
```